### PR TITLE
Add verticalAnchor prop in ecology examples

### DIFF
--- a/docs/ecology.md
+++ b/docs/ecology.md
@@ -11,7 +11,9 @@ By default, VictoryLabel behaves just like any other text element you’re used 
 
 ```playground
 <svg>
-  <VictoryLabel>Welcome!</VictoryLabel>
+  <VictoryLabel verticalAnchor="start">
+    Welcome!
+  </VictoryLabel>
 </svg>
 ```
 
@@ -23,6 +25,7 @@ Multiple lines are positioned how you’d expect and account for the given `line
 <svg>
   <VictoryLabel x={50} y={10}
     textAnchor="middle"
+    verticalAnchor="start"
     lineHeight={1.5}>
     {"data viz \n is \n fun!"}
   </VictoryLabel>


### PR DESCRIPTION
Oh hai!

I'm in the process of including these sweet, sweet docs in the main Victory site, and the label playgrounds are showing up a little off:
<img width="990" alt="screen shot 2015-12-17 at 11 10 39 am" src="https://cloud.githubusercontent.com/assets/6352327/11884109/5710d448-a4cc-11e5-8f8d-46b5ccb5677e.png">
<img width="929" alt="screen shot 2015-12-17 at 2 42 36 pm" src="https://cloud.githubusercontent.com/assets/6352327/11884143/92c9f12c-a4cc-11e5-860a-8cdeafdca2d3.png">

Adding `verticalAnchor="start"` seems to fix things:

<img width="941" alt="screen shot 2015-12-17 at 2 46 05 pm" src="https://cloud.githubusercontent.com/assets/6352327/11884215/fd953fc0-a4cc-11e5-8bfc-3f0ea30d2066.png">
<img width="930" alt="screen shot 2015-12-17 at 2 45 49 pm" src="https://cloud.githubusercontent.com/assets/6352327/11884219/093eff5a-a4cd-11e5-8787-28d89dba18fa.png">

Sound like an OK fix, @exogen and @coopy?
