### PR TITLE
[POC][NO MERGE] Feature npm package swapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,13 @@
   "scripts": {
     "postinstall": "cd lib || builder run npm:postinstall || (echo 'POSTINSTALL FAILED: If using npm v2, please upgrade to npm v3. See bug https://github.com/FormidableLabs/builder/issues/35' && exit 1)",
     "preversion": "builder run npm:preversion",
-    "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\"",
+    "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\" && builder run pkg-deps-to-dev",
+    "postversion": "git checkout package.json",
     "test": "builder run npm:test"
   },
   "dependencies": {
     "builder": "FormidableLabs/builder#feature-expand-archetype",
-    "builder-victory-component": "FormidableLabs/builder-victory-component#feature-expand-archetype",
+    "builder-victory-component": "FormidableLabs/builder-victory-component#feature-npm-package-swapping",
     "lodash": "^3.10.1",
     "radium": "^0.16.2",
     "victory-util": "FormidableLabs/victory-util#feature-expand-archetype"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
   "scripts": {
     "postinstall": "cd lib || builder run npm:postinstall || (echo 'POSTINSTALL FAILED: If using npm v2, please upgrade to npm v3. See bug https://github.com/FormidableLabs/builder/issues/35' && exit 1)",
     "preversion": "builder run npm:preversion",
-    "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\" && builder run pkg-deps-to-dev",
-    "postversion": "git checkout package.json",
+    "version": "builder run npm:version && git add dist && git commit -m \"Commit 'dist/' for publishing\"",
+    "postversion": "builder run pkg-deps-to-dev",
+    "postpublish": "git checkout package.json",
     "test": "builder run npm:test"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "test": "builder run npm:test"
   },
   "dependencies": {
-    "builder": "~2.4.0",
-    "builder-victory-component": "~0.2.1",
+    "builder": "FormidableLabs/builder#feature-expand-archetype",
+    "builder-victory-component": "FormidableLabs/builder-victory-component#feature-expand-archetype",
     "lodash": "^3.10.1",
     "radium": "^0.16.2",
-    "victory-util": "^5.0.0"
+    "victory-util": "FormidableLabs/victory-util#feature-expand-archetype"
   },
   "devDependencies": {
     "builder-victory-component-dev": "~0.2.1",


### PR DESCRIPTION
**NOTE - Not for merging, just for discussion**

Here is an experimental-only, no merge PR to demonstrate one option for slimming down the victory repo  installs. Basically, on an `npm version` command, we move both `builder` and `builder-victory-component` from `dependencies` and swap them back after the command is done (so devs won't see any difference).

This relies on a super-simple script at [`builder-victory-component/scripts/pkg-deps-to-dev.js`](https://github.com/FormidableLabs/builder-victory-component/compare/feature-npm-package-swapping#diff-7f9c96d179c4265f2f699d233545ca57) and a new archetype helper task:

``` js
"pkg-deps-to-dev": "node node_modules/builder-victory-component/scripts/pkg-deps-to-dev.js builder builder-victory-component",
```
### Release Workflow

Essentially, we have a new `postversion` task that now does:

``` sh
$ builder run pkg-deps-to-dev
```

which produces this diff:

``` diff
diff --git a/package.json b/package.json
index 144d6f6..2d048ad 100644
--- a/package.json
+++ b/package.json
@@ -22,8 +22,6 @@
     "test": "builder run npm:test"
   },
   "dependencies": {
-    "builder": "FormidableLabs/builder#feature-expand-archetype",
-    "builder-victory-component": "FormidableLabs/builder-victory-component#feature-npm-package-swapping",
     "lodash": "^3.10.1",
     "radium": "^0.16.2",
     "victory-util": "FormidableLabs/victory-util#feature-expand-archetype"
@@ -36,6 +34,8 @@
     "react-addons-test-utils": "^0.14.0",
     "react-dom": "0.14.x",
     "sinon": "^1.15.4",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.8.0",
+    "builder": "FormidableLabs/builder#feature-expand-archetype",
+    "builder-victory-component": "FormidableLabs/builder-victory-component#feature-npm-package-swapping"
   }
-}
+}
```

This is done **after** the git commits of `package.json` and `dist` from `npm version`.

This produces a dirty `package.json`, which is temporarily OK.

Once we run `npm publish`, this causes the `postpublish` task to execute undoing our `deps|devDeps` changes.

``` sh
$ git checkout package.json
```

and our local repo is a published, git tagged, pristine state.
### Discussion

The one disadvantage of this approach is it's kind of heavyweight -- basically _all_ of `builder` + archetype becomes a dev dependency. But, at least for our use cases here, `builder` is only a dev dep if you are pulling from NPM.

The thing I like about this approach a little bit better than trying to move all archetype deps to the `-dev` package is that if we _do_ need to builder `lib/` from a git install, we _just_ install `babel` and `webpack` and not all the **other** massive dev-stuff like karma, eslint, etc.

/cc @boygirl @coopy @exogen 
